### PR TITLE
Added new dockerfile for a cloud-sdk image that contains the firebase…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ build_firestore_emulator:
 
 build_rh_modsecurity_rate_limiter:
 	docker build ./rh-modsecurity-rate-limiter -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/modsecurity:latest
+
+cloud_sdk_firebase_cli:
+	docker build ./cloud-sdk-firebase-cli -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloud-sdk-firebase-cli:latest

--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ Build with
 ```shell
 make build_rh_modsecurity_rate_limiter
 ```
+
+## [Cloud SDK Firebase CLI](/cloud_sdk_firebase_cli/)
+Adds the Firebase cli to the base cloud-sdk image used by the database wipe concourse task to enable Firestore to be wiped as part of it.
+
+Build with
+```shell
+make cloud_sdk_firebase_cli
+```

--- a/cloud_sdk_firebase_cli/Dockerfile
+++ b/cloud_sdk_firebase_cli/Dockerfile
@@ -1,0 +1,4 @@
+FROM google/cloud-sdk
+
+RUN curl -Lo /usr/local/bin/firebase_tools https://firebase.tools/bin/linux/v11.2.2 \
+    && chmod +x /usr/local/bin/firebase_tools


### PR DESCRIPTION
…-cli tool

# Motivation and Context
We need a new image containing the Firebase CLI to allow concourse to wipe the data in our firestore as part of the database wipe task

# What has changed
Added new Dockerfile that installs the firebase cli onto the base cloud-sdk image used by the task currently
