### PR TITLE
Dockerizing Bastion

### DIFF
--- a/tinyproxy/Dockerfile
+++ b/tinyproxy/Dockerfile
@@ -1,0 +1,10 @@
+#
+# Dockerfile for tinyproxy
+#
+
+FROM alpine:3
+COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
+RUN apk update && apk add --no-cache tinyproxy=1.11.0-r0
+VOLUME /etc/tinyproxy
+EXPOSE 8888
+CMD ["tinyproxy", "-d"]

--- a/tinyproxy/tinyproxy.conf
+++ b/tinyproxy/tinyproxy.conf
@@ -71,4 +71,3 @@ ViaProxyName "tinyproxy"
 # Without these entries tinyproxy would allow connections from any port
 #
 ConnectPort 443
-ConnectPort 563

--- a/tinyproxy/tinyproxy.conf
+++ b/tinyproxy/tinyproxy.conf
@@ -1,0 +1,74 @@
+
+#
+# User/Group: This allows you to set the user and group that will be
+# used for tinyproxy after the initial binding to the port has been done
+# as the root user. Either the user or group name or the UID or GID
+# number may be used.
+#
+User nobody
+Group nobody
+
+#
+# Thsi is the port which tinyproxy will listen on
+#
+Port 8888
+
+#
+# Timeout: The maximum number of seconds of inactivity a connection is
+# allowed to have before it is closed by tinyproxy.
+#
+Timeout 600
+
+#
+# DefaultErrorFile: The HTML file that gets sent if there is no
+# HTML file defined with an ErrorFile keyword for the HTTP error
+# that has occured.
+#
+DefaultErrorFile "/usr/share/tinyproxy/default.html"
+
+#
+# StatFile: The HTML file that gets sent when a request is made
+# for the stathost.  If this file doesn't exist a basic page is
+# hardcoded in tinyproxy.
+#
+StatFile "/usr/share/tinyproxy/stats.html"
+
+#
+# LogLevel: Warning
+#
+# Set the logging level. Allowed settings are:
+#	Critical	(least verbose)
+#	Error
+#	Warning
+#	Notice
+#	Connect		(to log connections without Info's noise)
+#	Info		(most verbose)
+#
+LogLevel Info
+
+#
+# MaxClients: This is the absolute highest number of threads which will
+# be created. In other words, only MaxClients number of clients can be
+# connected at the same time.
+#
+MaxClients 100
+
+#
+# Only allow connections from the local machine as runing in a Docker container
+#
+Allow 127.0.0.1
+Allow ::1
+
+#
+# ViaProxyName: The "Via" header is required by the HTTP RFC, but using
+# the real host name is a security concern.  If the following directive
+# is enabled, the string supplied will be used as the host name in the
+# Via header; otherwise, the server's host name will be used.
+#
+ViaProxyName "tinyproxy"
+
+#
+# Without these entries tinyproxy would allow connections from any port
+#
+ConnectPort 443
+ConnectPort 563


### PR DESCRIPTION
# Motivation and Context
Dockerizing the Bastion to make it more secure, more manageable and faster to boot up.

# What has changed
Instead of an Ubuntu machine template that does an apt install tinyproxy - instead of that we use a Core Linux machine running a tinyproxy docker image.

# How to test?
Use the commands in the readme to build and push the docker image to the registry of your own choosing - then set that registry inside the cloud init service configuration.
