### PR TITLE
Updated mvn version and switched to use archive links

### DIFF
--- a/jdk17_maven_node16/Dockerfile
+++ b/jdk17_maven_node16/Dockerfile
@@ -1,9 +1,9 @@
 FROM eclipse-temurin:17.0.3_7-jdk
 
-ARG MAVEN_VERSION=3.8.5
+ARG MAVEN_VERSION=3.8.6
 ARG USER_HOME_DIR="/root"
-ARG SHA=89ab8ece99292476447ef6a6800d9842bbb60787b9b8a45c103aa61d2f205a971d8c3ddfb8b03e514455b4173602bd015e82958c0b3ddc1728a57126f773c743
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG SHA=f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \


### PR DESCRIPTION
# Motivation and Context
The version of maven we use in the jdk17-mvn-node16-npm docker image is no longer available at the url we used

# What has changed
Updated mvm to the latest 3.8.6 and changed url to point to the archive version so we don't get this issue again next time v3.8 is patched