### PR TITLE
224 build a python pipenv base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: jdk17-maven-node16 gcloud-firestore-emulator gcloud-pubsub-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy
+.PHONY: jdk17-maven-node16 gcloud-firestore-emulator gcloud-pubsub-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy python-pipenv
 
 jdk17-maven-node16:
 	docker build ./jdk17-maven-node16 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/jdk17-mvn-node16-npm:latest
@@ -22,6 +22,6 @@ cloudsql-proxy:
 	docker build ./cloudsql-proxy -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloudsql-proxy:latest
 
 python-pipenv:
-	docker build ./python-pipenv -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/python-pipenv:latest
+	docker build ./python-pipenv -t europe-west2-docker.pkg.dev/ons-ci-rm/docker/python-pipenv:latest
 
 build-all: jdk17-maven-node16 gcloud-pubsub-emulator gcloud-firestore-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy python-pipenv

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,7 @@ tinyproxy:
 cloudsql-proxy:
 	docker build ./cloudsql-proxy -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloudsql-proxy:latest
 
-build-all: jdk17-maven-node16 gcloud-pubsub-emulator gcloud-firestore-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy
+python-pipenv:
+	docker build ./python-pipenv -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/python-pipenv:latest
+
+build-all: jdk17-maven-node16 gcloud-pubsub-emulator gcloud-firestore-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy python-pipenv

--- a/README.md
+++ b/README.md
@@ -74,3 +74,13 @@ Build with
 ```shell
 make cloudsql-proxy
 ```
+
+## [Python Pipenv](python-pipenv)
+
+A python image with pipenv and other build dependencies pre installed.
+
+Build with
+
+```shell
+make python-pipenv
+```

--- a/python-pipenv/Dockerfile
+++ b/python-pipenv/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.10.4-alpine@sha256:54293681b8873556d38a4e6b04f52f4ac5c1d305ecf893a369892550d81b7c48
 RUN apk update
-RUN apk add build-base gcc 
+RUN apk add build-base gcc
+RUN apk add libc-dev linux-headers libffi-dev libpq-dev
 RUN pip3 install --user pipenv

--- a/python-pipenv/Dockerfile
+++ b/python-pipenv/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.10.4-alpine@sha256:54293681b8873556d38a4e6b04f52f4ac5c1d305ecf893a369892550d81b7c48
+RUN apk update
+RUN apk add build-base gcc 
+RUN pip3 install --user pipenv

--- a/python-pipenv/Dockerfile
+++ b/python-pipenv/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.4-alpine@sha256:54293681b8873556d38a4e6b04f52f4ac5c1d305ecf893a369892550d81b7c48
+FROM python:3.10.6-alpine@sha256:5b4e425e03038da758a35dc6f4473b4cf9bbadb9a7cdc2766d5d1d10ef1c9ca9
 RUN apk update
 RUN apk add build-base gcc
 RUN apk add libc-dev linux-headers libffi-dev libpq-dev

--- a/python-pipenv/Dockerfile
+++ b/python-pipenv/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.10.6-alpine@sha256:5b4e425e03038da758a35dc6f4473b4cf9bbadb9a7cdc2766d5d1d10ef1c9ca9
-RUN apk update
-RUN apk add build-base gcc
-RUN apk add libc-dev linux-headers libffi-dev libpq-dev
+FROM python:3.10.6-slim@sha256:ddfe4839f1516d0484944e07ea22200ede3d48828ecbf1f68eec1a9a06b79406
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+build-essential gcc 
 RUN pip3 install --user pipenv


### PR DESCRIPTION
# Motivation and Context
We currently use the standard python base image and install pipenv every time we build a service image

# What has changed
Created base python build image containing pipenv and other dependencies required for building our python services