### PR TITLE
556 Concourse gcloud auth critical warning

### DIFF
--- a/cloud-sdk-terraform/Dockerfile
+++ b/cloud-sdk-terraform/Dockerfile
@@ -21,3 +21,19 @@ ENV PATH="/home/cloudsdk/.tfenv/bin:${PATH}"
 # Install an initial version of terraform
 RUN tfenv install "$TERRAFORM_INITIAL_VERSION" && \
     tfenv use "$TERRAFORM_INITIAL_VERSION"
+
+
+### Install GKE plugin needed for authentication
+RUN apt-get update && \
+    apt-get install google-cloud-cli-gke-gcloud-auth-plugin
+
+###ENV PATH="/usr/local/gcloud/google-cloud-sdk/bin:${PATH}"
+##ENV export USE_GKE_GCLOUD_AUTH_PLUGIN=True
+##
+##RUN #gcloud components install gke-gcloud-auth-plugin --quiet --no-user-output-enabled
+
+
+
+#FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+#RUN gcloud components install kubectl
+#RUN gcloud components install gke-gcloud-auth-plugin

--- a/cloud-sdk-terraform/Dockerfile
+++ b/cloud-sdk-terraform/Dockerfile
@@ -3,9 +3,9 @@ FROM google/cloud-sdk:slim
 ARG TFENV_VERSION="v3.0.0"
 ARG TERRAFORM_INITIAL_VERSION="1.2.9"
 
-# Tfenv depends on unzip
 RUN apt-get update && \
-    apt-get install -y unzip && \
+    apt-get install google-cloud-cli-gke-gcloud-auth-plugin && `# GKE plugin needed for authentication` \
+    apt-get install -y unzip &&                                `# Tfenv depends on unzip` \
     rm -rf /var/lib/apt/lists/*
 
 # Install tfenv from the github release tarball
@@ -21,19 +21,3 @@ ENV PATH="/home/cloudsdk/.tfenv/bin:${PATH}"
 # Install an initial version of terraform
 RUN tfenv install "$TERRAFORM_INITIAL_VERSION" && \
     tfenv use "$TERRAFORM_INITIAL_VERSION"
-
-
-### Install GKE plugin needed for authentication
-RUN apt-get update && \
-    apt-get install google-cloud-cli-gke-gcloud-auth-plugin
-
-###ENV PATH="/usr/local/gcloud/google-cloud-sdk/bin:${PATH}"
-##ENV export USE_GKE_GCLOUD_AUTH_PLUGIN=True
-##
-##RUN #gcloud components install gke-gcloud-auth-plugin --quiet --no-user-output-enabled
-
-
-
-#FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
-#RUN gcloud components install kubectl
-#RUN gcloud components install gke-gcloud-auth-plugin

--- a/cloud-sdk-terraform/Dockerfile
+++ b/cloud-sdk-terraform/Dockerfile
@@ -6,7 +6,7 @@ ARG TERRAFORM_INITIAL_VERSION="1.2.9"
 RUN apt-get update && \
     apt-get install google-cloud-cli-gke-gcloud-auth-plugin && `# GKE plugin needed for authentication` \
     apt-get install -y unzip &&                                `# Tfenv depends on unzip` \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*                                `# Remove package files to reduce image size bloat`
 
 # Install tfenv from the github release tarball
 # Configure tfenv to use gpgv (which is included in the cloud-sdk) for verification

--- a/cloud-sdk-terraform/Dockerfile
+++ b/cloud-sdk-terraform/Dockerfile
@@ -4,9 +4,9 @@ ARG TFENV_VERSION="v3.0.0"
 ARG TERRAFORM_INITIAL_VERSION="1.2.9"
 
 RUN apt-get update && \
-    apt-get install google-cloud-cli-gke-gcloud-auth-plugin && `# GKE plugin needed for authentication` \
-    apt-get install -y unzip &&                                `# Tfenv depends on unzip` \
-    rm -rf /var/lib/apt/lists/*                                `# Remove package files to reduce image size bloat`
+    apt-get install google-cloud-cli-gke-gcloud-auth-plugin &&  `# GKE plugin needed for authentication` \
+    apt-get install -y unzip &&                                 `# Tfenv depends on unzip` \
+    rm -rf /var/lib/apt/lists/*                                 `# Remove package files to reduce image size bloat`
 
 # Install tfenv from the github release tarball
 # Configure tfenv to use gpgv (which is included in the cloud-sdk) for verification


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We were still getting the following errors in our Concourse pipeline jobs: 

```
WARNING: Accessing a Kubernetes Engine cluster requires the kubernetes commandline
client [kubectl]. To install, run
  $ gcloud components install kubectl

CRITICAL: ACTION REQUIRED: gke-gcloud-auth-plugin, which is needed for continued use of kubectl, was not found or is not executable. Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
```

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Bundled required plugin install into first `RUN` command with (hacky) comments

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Test locally or in your dev pipeline 

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/taVSwBIC/556-concourse-gcloud-auth-critical-warning-3