### PR TITLE
Use newer tinyproxy image

### DIFF
--- a/tinyproxy/Dockerfile
+++ b/tinyproxy/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alpine:3
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
-RUN apk update && apk add --no-cache tinyproxy=1.11.0-r0
+RUN apk update && apk add --no-cache tinyproxy=1.11.1-r2
 VOLUME /etc/tinyproxy
 EXPOSE 8888
 CMD ["tinyproxy", "-d"]


### PR DESCRIPTION
# Motivation and Context
The current Dockerfile for version 1.11.0-r0 no longer builds.  This PR updates it to the latest available version.

# What has changed
Updated the tinyproxy version.

# How to test?
Check that it builds locally.  

There'll be another PR on the way to point the app terraform to use it (the app terraform defaults to a specific version, where the Concourse terraform just uses latest).  

There are no breaking changes, and it should work like for like, as is.

# Links
https://trello.com/c/DJb1QP8L