### PR TITLE
SDCSRM-496 Update Tinyproxy

### DIFF
--- a/tinyproxy/Dockerfile
+++ b/tinyproxy/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alpine:3
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
-RUN apk update && apk add --no-cache tinyproxy=1.11.1-r3
+RUN apk update && apk add --no-cache tinyproxy=1.11.2-r0
 VOLUME /etc/tinyproxy
 EXPOSE 8888
 CMD ["tinyproxy", "-d"]


### PR DESCRIPTION
# Motivation and Context
Building the Tinyproxy image would fail due to it being outdated

# What has changed
Bumped Tinyproxy to 1.11.2 r0

# How to test?
run `make tinyproxy` to see that it builds

# Links
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-496)