### PR TITLE
SDCSRM-500 Fix Venom Strict-Transport-Security Failure

### DIFF
--- a/owasp-venom/venom_tests.yml
+++ b/owasp-venom/venom_tests.yml
@@ -126,6 +126,7 @@ testcases:
         url: '{{.target_site}}'
         skip_body: true
         info: >-
+          (Checking that Feature Policy is not in the header)
           This header has now been renamed to Permissions-Policy in the
           specification.
         timeout: '{{.request_timeout_in_seconds}}'
@@ -139,6 +140,7 @@ testcases:
         url: '{{.target_site}}'
         skip_body: true
         info: >-
+          (Checking that Public Key Pins is not in the header)
           This header has been deprecated by all major browsers and is no longer
           recommended. Avoid using it, and update existing code if possible!
         timeout: '{{.request_timeout_in_seconds}}'
@@ -152,6 +154,7 @@ testcases:
         url: '{{.target_site}}'
         skip_body: true
         info: >-
+          (Checking that Expect CT is not in the header)
           This header will likely become obsolete in June 2021. Since May 2018
           new certificates are expected to support SCTs by default. Certificates
           before March 2018 were allowed to have a lifetime of 39 months, those
@@ -167,6 +170,7 @@ testcases:
         url: '{{.target_site}}'
         skip_body: true
         info: >-
+          (Checking that X-XSS Protection is not in the header)
           The X-XSS-Protection header has been deprecated by modern browsers and
           its use can introduce additional security issues on the client side.
         timeout: '{{.request_timeout_in_seconds}}'

--- a/owasp-venom/venom_tests.yml
+++ b/owasp-venom/venom_tests.yml
@@ -3,7 +3,7 @@ name: HTTP security response headers test suites
 # VENOM HOME: https://github.com/ovh/venom
 
 vars:
-  target_site: "http://rh-ui:80/en/start"
+  target_site: "https://start.surveys.onsdigital.uk/en/start/"
   request_timeout_in_seconds: 20
 testcases:
   ###############################################


### PR DESCRIPTION
# Motivation and Context
Venom Test failures was failing

# What has changed
- Changed target site since Strict Transport Security (HSTS) requires HTTPS so swithced to pre-prod domain 
- I personally found the info messages misleading since I thought it was warning that we have depreciated headers enabled, when in actual fact it's not, so for the depreciated headers I've added in some extra info saying that it's checking it doesn't exist

# How to test?
Install Venom (https://github.com/ovh/venom?tab=readme-ov-file#installing)
Then run `venom run venom_tests.yml`

# Links
[SDCSRM-500](https://jira.ons.gov.uk/browse/SDCSRM-500)

# Screenshots (if appropriate):