### PR TITLE
Add new dockerfile for jdk17 node22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: jdk17-maven-node16 gcloud-firestore-emulator gcloud-pubsub-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy python-pipenv cloud-sdk-terraform eq-stub owasp-venom
+.PHONY: jdk17-maven-node16 jdk17-maven-node22 gcloud-firestore-emulator gcloud-pubsub-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy python-pipenv cloud-sdk-terraform eq-stub owasp-venom
 
 jdk17-maven-node16:
 	docker build ./jdk17-maven-node16 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/jdk17-mvn-node16-npm:latest
+
+jdk17-maven-node22:
+	docker build ./jdk17-maven-node22 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/jdk17-mvn-node22-npm:latest
 
 gcloud-pubsub-emulator:
 	docker build ./gcloud-pubsub-emulator -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/gcloud-pubsub-emulator:latest

--- a/README.md
+++ b/README.md
@@ -4,12 +4,22 @@ This repo is where the rm team store their docker image files used in builds and
 
 ## [JDK 17 Maven Node 16](/jdk17-maven-node16)
 
-A tooling image with JDK, Maven, and Node, to enable the building of JS front end resources in Java backend services.
+A tooling image with JDK, Maven, and Node version 16, to enable the building of JS front end resources in Java backend services.
 
 Build with
 
 ```shell
-make jdk17-maven-node-16
+make jdk17-maven-node16
+```
+
+## [JDK 17 Maven Node 22](/jdk17-maven-node16)
+
+A tooling image with JDK, Maven, and Node version 22, to enable the building of JS front end resources in Java backend services.
+
+Build with
+
+```shell
+make jdk17-maven-node22
 ```
 
 ## [GCloud PubSub Emulator](/gcloud-pubsub-emulator)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Build with
 make jdk17-maven-node16
 ```
 
-## [JDK 17 Maven Node 22](/jdk17-maven-node16)
+## [JDK 17 Maven Node 22](/jdk17-maven-node22)
 
 A tooling image with JDK, Maven, and Node version 22, to enable the building of JS front end resources in Java backend services.
 

--- a/jdk17-maven-node22/Dockerfile
+++ b/jdk17-maven-node22/Dockerfile
@@ -1,0 +1,24 @@
+FROM eclipse-temurin:17.0.3_7-jdk
+
+ARG MAVEN_VERSION=3.8.6
+ARG USER_HOME_DIR="/root"
+ARG SHA=f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
+  && curl -sL https://deb.nodesource.com/setup_22.x | bash - \
+  && apt-get install -y nodejs
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/jdk17-maven-node22/mvn-entrypoint.sh
+++ b/jdk17-maven-node22/mvn-entrypoint.sh
@@ -1,0 +1,50 @@
+#! /bin/sh -eu
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+  local ref="/usr/share/maven/ref"
+
+  if mkdir -p "${MAVEN_CONFIG}/repository" && touch "${log}" > /dev/null 2>&1 ; then
+      cd "${ref}"
+      local reflink=""
+      if cp --help 2>&1 | grep -q reflink ; then
+          reflink="--reflink=auto"
+      fi
+      if [ -n "$(find "${MAVEN_CONFIG}/repository" -maxdepth 0 -type d -empty 2>/dev/null)" ] ; then
+          # destination is empty...
+          echo "--- Copying all files to ${MAVEN_CONFIG} at $(date)" >> "${log}"
+          cp -rv ${reflink} . "${MAVEN_CONFIG}" >> "${log}"
+      else
+          # destination is non-empty, copy file-by-file
+          echo "--- Copying individual files to ${MAVEN_CONFIG} at $(date)" >> "${log}"
+          find . -type f -exec sh -eu -c '
+              log="${1}"
+              shift
+              reflink="${1}"
+              shift
+              for f in "$@" ; do
+                  if [ ! -e "${MAVEN_CONFIG}/${f}" ] || [ -e "${f}.override" ] ; then
+                      mkdir -p "${MAVEN_CONFIG}/$(dirname "${f}")"
+                      cp -rv ${reflink} "${f}" "${MAVEN_CONFIG}/${f}" >> "${log}"
+                  fi
+              done
+          ' _ "${log}" "${reflink}" {} +
+      fi
+      echo >> "${log}"
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+owd="$(pwd)"
+copy_reference_files
+unset MAVEN_CONFIG
+
+cd "${owd}"
+unset owd
+
+exec "$@"

--- a/jdk17-maven-node22/settings-docker.xml
+++ b/jdk17-maven-node22/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We currently use node 16 but its now obsolete so we want our services using node to use version 22
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
A new dockerfile added to build java and node services using versions jdk17 and node22.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build the dockerfile
Install node 22 locally and build supporttool and rops with it and check they still work.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-518
# Screenshots (if appropriate):