### PR TITLE
SDCSRM-582 Dependabot Fix Security Labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,4 @@ updates:
     labels:
       - "patch"
       - "dependencies"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major" ]
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,22 @@ updates:
       - "patch"
       - "dependencies"
     open-pull-requests-limit: 0
+
+# Update GitHub actions in workflows
+  - package-ecosystem: github-actions
+    directory: /
+    # Every week
+    schedule:
+      interval: weekly
+
+    labels:
+      - "patch"
+      - "dependencies"
+
+    groups:
+      # Group updates into fewer pull requests
+      gh-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
# Motivation and Context
Dependabot wasn't adding labels to security updates. This was due to the dependabot config being wrong, as it should be using `open-pull-requests-limit: 0` instead of the `ignore` tag

# What has changed
- Switched from the `ignore` tag to `open-pull-requests-limit: 0`
- Added security PRs for Github Actions

# How to test?
Check it looks ok

# Links
[Jira SDCSRM-582](https://jira.ons.gov.uk/browse/SDCSRM-582)
[Github Docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file)