### PR TITLE
SDCSRM-702 upgrade cloud-sql-proxy to V2

### DIFF
--- a/cloudsql-proxy/Dockerfile
+++ b/cloudsql-proxy/Dockerfile
@@ -3,5 +3,5 @@ EXPOSE 5432
 USER root
 RUN addgroup --gid 1000 cloudsqlproxy && adduser --system --uid 1000 cloudsqlproxy cloudsqlproxy
 USER cloudsqlproxy
-# CLOUDSQL_INSTANCE_ADDRESS format: <PROJECT>:<CLOUDSQL_INSTANCE_ID>=tcp:<PORT>
-ENTRYPOINT ["./cloud-sql-proxy", "--port 5432", "--address 0.0.0.0", "$CLOUDSQL_INSTANCE_ADDRESS", "--auto-iam-authn", "--private-ip=PRIVATE"]
+# CLOUDSQL_INSTANCE_ADDRESS format: <PROJECT>:<REGION>:<CLOUDSQL_INSTANCE_ID>
+ENTRYPOINT sh -c './cloud-sql-proxy --port 5432 --address 0.0.0.0 --private-ip "${CLOUDSQL_INSTANCE_ADDRESS}" --auto-iam-authn'

--- a/cloudsql-proxy/Dockerfile
+++ b/cloudsql-proxy/Dockerfile
@@ -1,7 +1,7 @@
-FROM eu.gcr.io/cloudsql-docker/gce-proxy:1.31.2-alpine
+FROM eu.gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.0-alpine
 EXPOSE 5432
 USER root
 RUN addgroup --gid 1000 cloudsqlproxy && adduser --system --uid 1000 cloudsqlproxy cloudsqlproxy
 USER cloudsqlproxy
 # CLOUDSQL_INSTANCE_ADDRESS format: <PROJECT>:<CLOUDSQL_INSTANCE_ID>=tcp:<PORT>
-CMD ./cloud_sql_proxy -enable_iam_login -instances=$CLOUDSQL_INSTANCE_ADDRESS -ip_address_types=PRIVATE 
+ENTRYPOINT ["./cloud-sql-proxy", "--port 5432", "--address 0.0.0.0", "$CLOUDSQL_INSTANCE_ADDRESS", "--auto-iam-authn", "--private-ip=PRIVATE"]


### PR DESCRIPTION
# Motivation and Context
Cloud-sql-proxy has a new major version (V2), while V1 is still being supported we may be able to make use of V2 features in the future.

# What has changed
- changed the cloud sql proxy version to `2.14.0`
- changed from command to entrypoint in the docker file and updated flags for v2

# How to test?
Apply the terraform PR with the instructions https://github.com/ONSdigital/ssdc-rm-terraform/pull/635

I already have tagged the changes to docker `sdcrm-702-cloud-sql-proxy-v2` which can be used

# Links
[Jira SDCSRM-702](https://jira.ons.gov.uk/browse/SDCSRM-702)

# Screenshots (if appropriate):