### PR TITLE
SDCSRM-1117 Code Scanning Security Alert

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -10,6 +10,10 @@ jobs:
   test-image-builds:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
     steps:
 
     - name: Login to Docker Hub


### PR DESCRIPTION
# Motivation and Context
There was a security alert about the build-images workflow not contain permissions

# What has changed
- Added permissions

# How to test?
Nothing to test, the github workflow should run and pass

# Links
[SDCSRM-1117](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1117)
https://github.com/ONSdigital/ssdc-rm-dockerfiles/security/code-scanning/2

# Screenshots (if appropriate):