### PR TITLE
SDCSRM-1527 Bump Github actions for Node 24

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build Images
       run: make build-all

--- a/tinyproxy/Dockerfile
+++ b/tinyproxy/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alpine:3
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
-RUN apk update && apk add --no-cache tinyproxy=1.11.2-r0
+RUN apk update && apk add --no-cache tinyproxy=1.11.3-r0
 VOLUME /etc/tinyproxy
 EXPOSE 8888
 CMD ["tinyproxy", "-d"]


### PR DESCRIPTION
# Motivation and Context
GitHub Actions are removing support for node 20, so we need to bump our actions so they are compatible with Node 24

It seems that tinyproxy 1.11.2-r0 is no longer available so I've bumped it to 1.11.3-r0

# What has changed
Bumped github actions

# How to test?
Check the actions run on this PR and there are no warnings

# Links
[SDCSRM-1527](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1527)

# Screenshots (if appropriate):