### PR TITLE
Corporate Mac changes for docker/podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ modsecurity:
 	$(DOCKER) build --platform linux/amd64 ./modsecurity -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/modsecurity:latest
 
 cloud-sdk-firebase-cli:
-	$(DOCKER) build --platform linux/amd64 ./cloud-sdk-firebase-cli --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloud-sdk-firebase-cli:latest
+	$(DOCKER) build --platform linux/amd64 ./cloud-sdk-firebase-cli -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloud-sdk-firebase-cli:latest
 
 tinyproxy:
-	$(DOCKER) build --platform linux/amd64 ./tinyproxy --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/tinyproxy:latest
+	$(DOCKER) build --platform linux/amd64 ./tinyproxy -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/tinyproxy:latest
 
 cloudsql-proxy:
-	$(DOCKER) build --platform linux/amd64 ./cloudsql-proxy --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloudsql-proxy:latest
+	$(DOCKER) build --platform linux/amd64 ./cloudsql-proxy -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloudsql-proxy:latest
 
 python-pipenv: python-pipenv-3.12
 

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,47 @@
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER ?= $(shell if [ "$$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 .PHONY: jdk17-maven-node22 gcloud-firestore-emulator gcloud-pubsub-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy python-pipenv cloud-sdk-terraform eq-stub owasp-venom
 
 jdk17-maven-node22:
-	docker build ./jdk17-maven-node22 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/jdk17-mvn-node22-npm:latest
+	$(DOCKER) build --platform linux/amd64 ./jdk17-maven-node22 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/jdk17-mvn-node22-npm:latest
 
 gcloud-pubsub-emulator:
-	docker build ./gcloud-pubsub-emulator -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/gcloud-pubsub-emulator:latest
+	$(DOCKER) build --platform linux/amd64 ./gcloud-pubsub-emulator -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/gcloud-pubsub-emulator:latest
 
 gcloud-firestore-emulator:
-	docker build ./gcloud-firestore-emulator -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/gcloud-firestore-emulator:latest
+	$(DOCKER) build --platform linux/amd64 ./gcloud-firestore-emulator -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/gcloud-firestore-emulator:latest
 
 modsecurity:
-	docker build ./modsecurity -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/modsecurity:latest
+	$(DOCKER) build --platform linux/amd64 ./modsecurity -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/modsecurity:latest
 
 cloud-sdk-firebase-cli:
-	docker build ./cloud-sdk-firebase-cli -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloud-sdk-firebase-cli:latest
+	$(DOCKER) build --platform linux/amd64 ./cloud-sdk-firebase-cli --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloud-sdk-firebase-cli:latest
 
 tinyproxy:
-	docker build ./tinyproxy -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/tinyproxy:latest
+	$(DOCKER) build --platform linux/amd64 ./tinyproxy --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/tinyproxy:latest
 
 cloudsql-proxy:
-	docker build ./cloudsql-proxy -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloudsql-proxy:latest
+	$(DOCKER) build --platform linux/amd64 ./cloudsql-proxy --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloudsql-proxy:latest
 
 python-pipenv: python-pipenv-3.12
 
 python-pipenv-3.13:
-	docker build --build-arg="PYTHON_TAG=$$(cat python-pipenv/python-3.13-tag.txt)" ./python-pipenv -t europe-west2-docker.pkg.dev/ons-ci-rm/docker/python-pipenv:3.13
+	$(DOCKER) build --platform linux/amd64 --build-arg="PYTHON_TAG=$$(cat python-pipenv/python-3.13-tag.txt)" ./python-pipenv -t europe-west2-docker.pkg.dev/ons-ci-rm/docker/python-pipenv:3.13
 
 python-pipenv-3.12:
-	docker build --build-arg="PYTHON_TAG=$$(cat python-pipenv/python-3.12-tag.txt)" ./python-pipenv -t europe-west2-docker.pkg.dev/ons-ci-rm/docker/python-pipenv:3.12
+	$(DOCKER) build --platform linux/amd64 --build-arg="PYTHON_TAG=$$(cat python-pipenv/python-3.12-tag.txt)" ./python-pipenv -t europe-west2-docker.pkg.dev/ons-ci-rm/docker/python-pipenv:3.12
 
 python-pipenv-3.11:
-	docker build --build-arg="PYTHON_TAG=$$(cat python-pipenv/python-3.11-tag.txt)" ./python-pipenv -t europe-west2-docker.pkg.dev/ons-ci-rm/docker/python-pipenv:3.11
+	$(DOCKER) build --platform linux/amd64 --build-arg="PYTHON_TAG=$$(cat python-pipenv/python-3.11-tag.txt)" ./python-pipenv -t europe-west2-docker.pkg.dev/ons-ci-rm/docker/python-pipenv:3.11
 
 cloud-sdk-terraform:
-	docker build ./cloud-sdk-terraform -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloud-sdk-terraform:latest
+	$(DOCKER) build --platform linux/amd64 ./cloud-sdk-terraform -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/cloud-sdk-terraform:latest
 
 eq-stub:
-	docker build ./eq-stub -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-eq-stub:latest
+	$(DOCKER) build --platform linux/amd64 ./eq-stub -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-eq-stub:latest
 
 owasp-venom:
-	docker build ./owasp-venom -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/venom:latest
+	$(DOCKER) build --platform linux/amd64 ./owasp-venom -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/venom:latest
 
 build-all: gcloud-pubsub-emulator gcloud-firestore-emulator modsecurity cloud-sdk-firebase-cli tinyproxy cloudsql-proxy python-pipenv-3.11 python-pipenv-3.12 cloud-sdk-terraform eq-stub owasp-venom

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repo is where the rm team store their docker image files used in builds and tooling.
 
+Podman and Docker are both supported for building and running the application.
+By default the Makefile will use `docker` unless you are on an `arm64` architecture (e.g. M1/M2 Mac) in which case it will use `podman`.
+You can override this by setting the `DOCKER` environment variable to either `docker` or `podman`.
+For example, to force using `docker` on an M1/M2 Mac:
+```shell
+DOCKER=docker make <command>
+```
 ## [JDK 17 Maven Node 22](/jdk17-maven-node22)
 
 A tooling image with JDK, Maven, and Node version 22, to enable the building of JS front end resources in Java backend services.


### PR DESCRIPTION
# Motivation and Context
Updates to allow Makefile commands to work on both corporate and off-net Macbooks.

# What has changed
Updated version allowlisting Makefile to allow docker/podman builds depending on Mac architecture.

# How to test?
Run `make build-all` from the allowlisting directory

# Links
[SDCSRM-1571](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1571)

[SDCSRM-1571]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ