### PR TITLE
SDCSRM-1269: Bump cloud-sdk-terraform tfenv and Terraform versions

### DIFF
--- a/cloud-sdk-terraform/Dockerfile
+++ b/cloud-sdk-terraform/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk:slim
 
-ARG TFENV_VERSION="v3.0.0"
-ARG TERRAFORM_INITIAL_VERSION="1.7.2"
+ARG TFENV_VERSION="v3.2.2"
+ARG TERRAFORM_INITIAL_VERSION="1.15.7"
 
 RUN apt-get update && \
     apt-get install google-cloud-cli-gke-gcloud-auth-plugin &&  `# GKE plugin needed for authentication` \


### PR DESCRIPTION
# Motivation and Context
This is a follow-up to https://github.com/ONSdigital/ssdc-rm-terraform/pull/720 and https://github.com/ONSdigital/ssdc-rm-concourse/pull/454, updating the Terraform version built into image so it doesn't have to be downloaded on each use.

# What has changed
* Bumped tfenv and Terraform versions to match the PRs above.

# How to test?
* Build the image and run `terraform --version`.

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1269
