### PR TITLE
SDCSRM-1619: Bump cloud-sql-proxy base image from 2.14.0 to 2.24.1

### DIFF
--- a/cloudsql-proxy/Dockerfile
+++ b/cloudsql-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.0-alpine
+FROM eu.gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.24.1-alpine
 EXPOSE 5432
 USER root
 RUN addgroup --gid 1000 cloudsqlproxy && adduser --system --uid 1000 cloudsqlproxy cloudsqlproxy


### PR DESCRIPTION
# Motivation and Context

SCC reports 41 active SOFTWARE_VULNERABILITY findings against `bastion-vm` in
both `ons-ssdc-rm-preprod` and `ons-ssdc-rm-prod`. All 41 resolve to a single
file — the `cloud-sql-proxy` binary under `/var/lib/docker/overlay2/.../diff/` —
and are Go module vulnerabilities (e.g. CVE-2026-39832 in `golang.org/x/crypto`).

These are ours to fix, not Google's: the image is built from
`ssdc-rm-dockerfiles/cloudsql-proxy` and pinned in Terraform via
`cloudsql_proxy_docker_tag`. No node upgrade will clear them.

The base image was pinned at 2.14.0; upstream latest is 2.24.1.

# What has changed

Bumped the base image from `cloud-sql-proxy:2.14.0-alpine` to `2.24.1-alpine`.
No other changes — the `USER`/`ENTRYPOINT` setup is unchanged.

# How to test?

Built locally against the new base and verified the surrounding Dockerfile
still holds, since ten minor versions is enough for the image layout to move:

- Image builds cleanly.
- `addgroup --gid 1000` does not collide with the base image's user
  (base runs as `nonroot`/65532).
- `WorkingDir` is still `/`, so the relative `./cloud-sql-proxy` in the
  ENTRYPOINT continues to resolve. This was the main risk — a layout change
  would have broken the bastion's DB tunnel at runtime, not at build time.
- Binary present and executable (mode 755), reports
  `cloud-sql-proxy version 2.24.1+container.alpine`.
- All four ENTRYPOINT flags still supported: `--port`, `--address`,
  `--private-ip`, `--auto-iam-authn`.

Post-merge, Concourse `build-cloudsql-proxy` publishes the new version. The
Terraform `cloudsql_proxy_docker_tag` bump (0.3.0 -> 0.3.1) is a follow-up PR
in `ssdc-rm-terraform`; applying it recreates the bastion VMs and will drop
any live SSH tunnels, so it wants a quiet window.

# Links

- https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1619
- Upstream release: https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases/tag/v2.24.1
- Follow-up: `cloudsql_proxy_docker_tag` in `ssdc-rm-terraform/tfvars/ons-ssdc-rm-{preprod,prod}.tfvars`
